### PR TITLE
feat: added not-found and error pages

### DIFF
--- a/apps/web/app/dashboard/error.tsx
+++ b/apps/web/app/dashboard/error.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import type { Metadata } from "next";
+
+// Icons
+import Logo from "@/public/logo.svg";
+import { Button } from "@/components/ui/button";
+import { ArrowLeftIcon } from "lucide-react";
+
+// Components
+
+export const metadata: Metadata = {
+	title: "Autenticação",
+};
+
+const randomPhrases = ["oops", "erro"];
+
+export default function ErrorPage({
+	error,
+	reset,
+}: {
+	error: Error & { digest?: string };
+	reset: () => void;
+}) {
+	console.log(error, error.digest);
+
+	return (
+		<div className="flex min-h-screen flex-col md:flex-row">
+			<div className="bg-primary relative flex flex-col items-center justify-center gap-4 overflow-hidden rounded-b bg-[linear-gradient(180deg,_#2563EB_0%,_#3B82F6_100%)] px-6 py-12 text-white md:m-8 md:w-1/2 md:rounded md:p-12">
+				<Logo className="h-10 md:h-12" />
+				<span className="pointer-events-none absolute top-1/2 left-1/2 z-10 hidden h-full w-[125%] -translate-x-1/2 -translate-y-1/2 flex-wrap items-center justify-center gap-6 text-[3vw] font-bold wrap-anywhere select-none md:flex">
+					{Array.from({ length: 250 }, (_, i) => (
+						<span
+							key={i}
+							className="block opacity-5"
+							style={{
+								letterSpacing: "0.05em",
+							}}
+						>
+							{
+								randomPhrases[
+									Math.floor(
+										Math.random() * randomPhrases.length,
+									)
+								]
+							}
+						</span>
+					))}
+				</span>
+				<span className="absolute top-0 right-0 bottom-0 left-0 z-10 flex h-full w-full flex-wrap items-center justify-center gap-4 text-[6vw] font-bold select-none md:hidden">
+					{Array.from({ length: 24 }, (_, i) => (
+						<span
+							key={i}
+							className="block opacity-10"
+							style={{
+								letterSpacing: "0.03em",
+							}}
+						>
+							{
+								randomPhrases[
+									Math.floor(
+										Math.random() * randomPhrases.length,
+									)
+								]
+							}
+						</span>
+					))}
+				</span>
+			</div>
+
+			{/* Right Part */}
+			<div className="flex w-full flex-1 flex-col items-center justify-center p-8 md:w-1/2">
+				<div className="flex w-full max-w-sm flex-col items-start justify-center gap-6 max-md:pb-8">
+					<div className="flex flex-col items-start justify-start gap-6">
+						<h1 className="text-3xl leading-[95%] font-bold">
+							Ops… algo deu errado nos nossso bastidores.
+						</h1>
+						<p>
+							Estamos trabalhando nos ajustes — recarregue a
+							página ou tente novamente em alguns instantes.
+						</p>
+						<span className="bg-muted w-full rounded-md border font-mono text-sm">
+							{error.message && error.message}
+						</span>
+						<Button size={"lg"} onClick={() => reset()}>
+							<ArrowLeftIcon />
+							Tentar novamente
+						</Button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -7,6 +7,7 @@
 @theme inline {
 	/* Base design tokens */
 	--font-sans: var(--font-hanken-grotesk);
+	--font-dashboard: var(--font-rem);
 	--font-mono: JetBrains Mono, monospace;
 	--font-serif: Source Serif 4, serif;
 

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,86 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+// Icons
+import Logo from "@/public/logo.svg";
+import { Button } from "@/components/ui/button";
+import { ArrowLeftIcon } from "lucide-react";
+
+// Components
+
+export const metadata: Metadata = {
+	title: "Autenticação",
+};
+
+const randomPhrases = ["404", "not found", "não encontrado"];
+
+export default function NotFoundPage() {
+	return (
+		<div className="flex min-h-screen flex-col md:flex-row">
+			<div className="bg-primary relative flex flex-col items-center justify-center gap-4 overflow-hidden rounded-b bg-[linear-gradient(180deg,_#2563EB_0%,_#3B82F6_100%)] px-6 py-12 text-white md:m-8 md:w-1/2 md:rounded md:p-12">
+				<Logo className="h-10 md:h-12" />
+				<span className="pointer-events-none absolute top-1/2 left-1/2 z-10 hidden h-full w-[125%] -translate-x-1/2 -translate-y-1/2 flex-wrap items-center justify-center gap-6 text-[3vw] font-bold wrap-anywhere select-none md:flex">
+					{Array.from({ length: 250 }, (_, i) => (
+						<span
+							key={i}
+							className="block opacity-5"
+							style={{
+								letterSpacing: "0.05em",
+							}}
+						>
+							{
+								randomPhrases[
+									Math.floor(
+										Math.random() * randomPhrases.length,
+									)
+								]
+							}
+						</span>
+					))}
+				</span>
+				<span className="absolute top-0 right-0 bottom-0 left-0 z-10 flex h-full w-full flex-wrap items-center justify-center gap-4 text-[6vw] font-bold select-none md:hidden">
+					{Array.from({ length: 24 }, (_, i) => (
+						<span
+							key={i}
+							className="block opacity-10"
+							style={{
+								letterSpacing: "0.03em",
+							}}
+						>
+							{
+								randomPhrases[
+									Math.floor(
+										Math.random() * randomPhrases.length,
+									)
+								]
+							}
+						</span>
+					))}
+				</span>
+			</div>
+
+			{/* Right Part */}
+			<div className="flex w-full flex-1 flex-col items-center justify-center p-8 md:w-1/2">
+				<div className="flex w-full max-w-sm flex-col items-start justify-center gap-6 max-md:pb-8">
+					<h1 className="font-sans text-6xl font-black">404</h1>
+					<div className="flex flex-col items-start justify-start gap-6">
+						<h2 className="text-3xl leading-[95%] font-bold">
+							Ops… esse evento não foi agendado
+						</h2>
+						<p>
+							A página que você procurou (ainda) não existe.
+							<br /> Volte para o início e continue gerenciando
+							seus eventos com a gente.
+						</p>
+						<Button size={"lg"} asChild>
+							<Link href={`/`}>
+								<ArrowLeftIcon />
+								Voltar para o início
+							</Link>
+						</Button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
This pull request introduces two new pages (`ErrorPage` and `NotFoundPage`) to improve error handling and user experience, along with a minor update to global styles. Below are the key changes:

### New Pages for Error Handling and Not Found Scenarios:
* **`apps/web/app/dashboard/error.tsx`:** Added an `ErrorPage` component to display a user-friendly error message with a retry button. The page includes a visually appealing design with a gradient background and dynamic text effects.
* **`apps/web/app/not-found.tsx`:** Added a `NotFoundPage` component to handle 404 errors. It provides a clear message and a button to navigate back to the homepage, with a similar design pattern as the `ErrorPage`.

### Global Styles Update:
* **`apps/web/app/globals.css`:** Introduced a new CSS variable `--font-dashboard` for dashboard font styling, enhancing design consistency.